### PR TITLE
Added useEffect cleanup to avoid memory leaks

### DIFF
--- a/src/Joke.js
+++ b/src/Joke.js
@@ -4,9 +4,11 @@ const Joke = () => {
   const [joke, setJoke] = useState({})
 
   useEffect(() => {
-    fetch('https://official-joke-api.appspot.com/jokes/random')
+    const abortController = new AbortController()
+    fetch('https://official-joke-api.appspot.com/jokes/random', { signal: abortController.signal })
       .then((response) => response.json())
       .then((data) => setJoke(data))
+    return () => abortController.abort()
   }, [])
 
   const { setup, punchline } = joke

--- a/src/Stories.js
+++ b/src/Stories.js
@@ -4,9 +4,11 @@ const Stories = () => {
   const [stories, setStories] = useState([])
 
   useEffect(() => {
-    fetch('https://news-proxy-230704.appspot.com/topstories')
+    const abortController = new AbortController()
+    fetch('https://news-proxy-230704.appspot.com/topstories', { signal: abortController.signal })
       .then((response) => response.json())
       .then((data) => setStories(data))
+    return () => abortController.abort();
   }, [])
 
   return (


### PR DESCRIPTION
Dont mean to impose, just a quick update to show how to manage cleanup on a useEffect that uses fetch.

The point of this is to avoid any memory leaks. As much as this app is small I noticed you mentioned you were using this to practice, so thought it may be helpful to learn this one early on.

Code is nice and clean

I do notice that your using semantic HTML `section` for example so it may be worthwhile changing your main entry from a `div` to a `main`, but only if you feel it fits.

Great code so far :)